### PR TITLE
Index and add material types

### DIFF
--- a/backend/plugin_init.rb
+++ b/backend/plugin_init.rb
@@ -1,0 +1,18 @@
+if !AppConfig[:plugins].include?("material_types")
+
+  puts <<EOF
+
+************************************************************************
+***
+*** PLUGIN ERROR:
+***
+*** The extended_advanced_search plugin depends on the material_types
+*** plugin.  Please copy this plugin to the `plugins` directory and
+*** update your AppConfig[:plugins] configuration.
+***
+************************************************************************
+
+EOF
+
+  raise "Plugin error: extended_advanced_search requires material_types"
+end

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -35,6 +35,17 @@ en:
       has_rights_statements_u_ubool: Rights Statements?
       restrictions_apply: Restrictions Apply?
       use_restrictions: Use Restrictions?
+      material_type_works_of_art_u_ubool: Material Type - Works of Art?
+      material_type_audiovisual_materials_u_ubool: Material Type - Audiovisual Materials?
+      material_type_books_u_ubool: Material Type - Books?
+      material_type_electronic_documents_u_ubool: Material Type - Electric Documents?
+      material_type_games_u_ubool: Material Type - Games?
+      material_type_microforms_u_ubool: Material Type - Microforms?
+      material_type_maps_u_ubool: Material Type - Maps?
+      material_type_manuscripts_u_ubool: Material Type - Manuscripts?
+      material_type_photographs_u_ubool: Material Type - Photographs?
+      material_type_realia_u_ubool: Material Type - Realia?
+      material_type_serials_u_ubool: Material Type - Serials?
     date_field_query_field:
       accession_date_u_udate: Accession Date
       date_begin_u_udate: Begin

--- a/indexer/common_indexer.rb
+++ b/indexer/common_indexer.rb
@@ -18,6 +18,20 @@ class CommonIndexer
         if accession_date
           doc['accession_date_u_udate'] = accession_date
         end
+
+        if record['record']['material_types']
+          doc['material_type_works_of_art_u_ubool'] = record['record']['material_types']['works_of_art']
+          doc['material_type_audiovisual_materials_u_ubool'] = record['record']['material_types']['audiovisual_materials']
+          doc['material_type_books_u_ubool'] = record['record']['material_types']['books']
+          doc['material_type_electronic_documents_u_ubool'] = record['record']['material_types']['electronic_documents']
+          doc['material_type_games_u_ubool'] = record['record']['material_types']['games']
+          doc['material_type_microforms_u_ubool'] = record['record']['material_types']['microforms']
+          doc['material_type_maps_u_ubool'] = record['record']['material_types']['maps']
+          doc['material_type_manuscripts_u_ubool'] = record['record']['material_types']['manuscripts']
+          doc['material_type_photographs_u_ubool'] = record['record']['material_types']['photographs']
+          doc['material_type_realia_u_ubool'] = record['record']['material_types']['realia']
+          doc['material_type_serials_u_ubool'] = record['record']['material_types']['serials']
+        end
       end
     }
 

--- a/migrations/003_add_material_types_search_fields.rb
+++ b/migrations/003_add_material_types_search_fields.rb
@@ -1,0 +1,29 @@
+Sequel.migration do
+
+  up do
+    $stderr.puts("Adding material type boolean fields to the staff advanced search")
+    enum = self[:enumeration].filter(:name => 'boolean_field_query_field').select(:id)
+    [
+      "material_type_works_of_art_u_ubool",
+      "material_type_audiovisual_materials_u_ubool",
+      "material_type_books_u_ubool",
+      "material_type_electronic_documents_u_ubool",
+      "material_type_games_u_ubool",
+      "material_type_microforms_u_ubool",
+      "material_type_maps_u_ubool",
+      "material_type_manuscripts_u_ubool",
+      "material_type_photographs_u_ubool",
+      "material_type_realia_u_ubool",
+      "material_type_serials_u_ubool",
+    ].each do |field|
+      self[:enumeration_value].insert(:enumeration_id => enum, :value => field)
+    end
+
+    # And re-index all accessions
+    [:accession].each do |table|
+      self[table].update(:system_mtime => Time.now)
+    end
+  end
+
+end
+


### PR DESCRIPTION
Raise an exception if the plugin 'material_types' is not included (it is a new dependency).

Add all material types as boolean search fields and index accordingly.
