### PR TITLE
Update CommonIndexer to IndexerCommon for 2.2.2+

### DIFF
--- a/indexer/common_indexer.rb
+++ b/indexer/common_indexer.rb
@@ -1,6 +1,6 @@
 require_relative '../linked_agent_fields'
 
-class CommonIndexer
+class IndexerCommon
 
   self.add_attribute_to_resolve("linked_events")
 


### PR DESCRIPTION
Trivial update to the class name because of:

https://github.com/archivesspace/archivesspace/commit/531e3ccaed008fcbed252ab0fa7d252f144034a4